### PR TITLE
Addition of "API-like" TRACSInterface and irradiation GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,12 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 #include_directories(${CMAKE_SOURCE_DIR}/build/bin)
 
 if(COVERAGE_ENABLED)
-    set(CMAKE_CXX_FLAGS_DEBUG "-Wall -fPIC  -ggdb -fprofile-arcs -ftest-coverage")
+    set(CMAKE_CXX_FLAGS_DEBUG "-Wall -O0 -fPIC  -ggdb -fprofile-arcs -ftest-coverage")
 else()
-    set(CMAKE_CXX_FLAGS_DEBUG "-Wall  -ggdb")
+    set(CMAKE_CXX_FLAGS_DEBUG "-Wall -O0 -ggdb")
 endif()
 
-set(CMAKE_CXX_FLAGS_RELEASE "-Wall -O2")
+set(CMAKE_CXX_FLAGS_RELEASE "-Wall -O0")
 
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 set(SRC SMSDSubDomains.cpp SMSDetector.cpp
     Carrier.cpp CarrierMobility.cpp CarrierTransport.cpp
     CarrierCollection.cpp utilities.cpp
-    qcustomplot.cpp qcustomplot.h H1DConvolution.C)
+	qcustomplot.cpp qcustomplot.h H1DConvolution.C TRACSInterface.cpp)
 
 set(HEADERS qcustomplot.h)
 

--- a/src/SMSDetector.cpp
+++ b/src/SMSDetector.cpp
@@ -94,6 +94,8 @@ void SMSDetector::solve_d_u()
 	if (_fluence <= 0)
 	{
 		_L_p.f = fpois;
+		// Idiot-proofing
+		_trapping_time = std::numeric_limits<double>::max();
 	}
 	else 
 	{
@@ -422,6 +424,21 @@ void SMSDetector::set_trapping_time(double trapping_tau)
 void SMSDetector::set_fluence(double fluencia)
 {
   _fluence = fluencia;
+}
+
+/*
+ * Setter for changing the space charge distribution
+ */
+void SMSDetector::set_neff_param(std::vector<double> neff_parameters)
+{
+  _neff_param[0] = neff_parameters[0]; // y0
+  _neff_param[1] = neff_parameters[1]; // y1
+  _neff_param[2] = neff_parameters[2]; // y2
+  _neff_param[3] = neff_parameters[3]; // y3
+  _neff_param[4] = 0.0; // z0 (Idiot proof)
+  _neff_param[5] = neff_parameters[5]; // z1
+  _neff_param[6] = neff_parameters[6]; // z2
+  _neff_param[7] = _depth; // z3 (Idiot proof)
 }
 
 SMSDetector::~SMSDetector()

--- a/src/SMSDetector.h
+++ b/src/SMSDetector.h
@@ -109,15 +109,15 @@ class SMSDetector
     double get_y_max();
     double get_temperature();
     double get_trapping_time();
-		double get_fluence();
-		double get_depth();
-		double get_pitch();
-		double get_width();
-		int get_nns();
-		char get_bulk_type();
-		char get_implant_type();
-		double get_vbias();
-		double get_vdep();
+	double get_fluence();
+	double get_depth();
+	double get_pitch();
+	double get_width();
+	int get_nns();
+	char get_bulk_type();
+	char get_implant_type();
+	double get_vbias();
+	double get_vdep();
 
     // some other methods
     bool is_out(const std::array< double,2> &x);

--- a/src/SMSDetector.h
+++ b/src/SMSDetector.h
@@ -3,6 +3,7 @@
 
 #include <dolfin.h>
 #include <cmath> 
+#include <limits>  // std::numeric_limits
 
 #include "Poisson.h"
 #include "Gradient.h"
@@ -89,7 +90,7 @@ class SMSDetector
     void set_temperature(double temperature);
     void set_trapping_time(double trapping_tau);
     void set_fluence(double fluencia);
-
+	void set_neff_param(std::vector<double> neff_parameters);
     // solve potentials
     void solve_w_u();
     void solve_d_u();

--- a/src/TRACSInterface.cpp
+++ b/src/TRACSInterface.cpp
@@ -1,0 +1,200 @@
+#include "TRACSInterface.h"
+
+
+TRACSInterface::TRACSInterface(std::string filename)
+{
+	neff_param = std::vector<double>(8,0);
+	utilities::parse_config_file(filename, carrierFile, depth, width, pitch, nns, temp, trapping, fluence, n_cells_x, n_cells_y, bulk_type, implant_type, C, dt, max_time, vBias, vDepletion, zPos, yPos, neff_param);
+
+	// Initialize vectors / n_Steps / detector / set default zPos, yPos, vBias / carrier_collection 
+	if (fluence <= 0) // if no fluence -> no trapping
+	{
+		trapping = std::numeric_limits<double>::max();
+	} else {}
+
+	n_tSteps = (int) std::floor(max_time / dt);
+
+	std::valarray<double> i_elec ((size_t) n_tSteps);	
+	std::valarray<double> i_hole ((size_t) n_tSteps);
+	std::valarray<double> i_total((size_t) n_tSteps);
+	i_hole = 0;
+	i_elec = 0;
+	i_total = 0;
+
+	parameters["allow_extrapolation"] = true;
+
+	SMSDetector detector(pitch, width, depth, nns, bulk_type, implant_type, n_cells_x, n_cells_y, temp, trapping, fluence, neff_param);
+	pDetector = &detector;
+	carrierCollection = new CarrierCollection(pDetector);
+	QString carrierFileName = QString::fromUtf8(carrierFile.c_str());
+	carrierCollection->add_carriers_from_file(carrierFileName);
+
+
+	pDetector->set_voltages(vBias, vDepletion);
+	pDetector->solve_w_u();
+	pDetector->solve_d_u();
+	pDetector->solve_w_f_grad();
+	pDetector->solve_d_f_grad();
+	pDetector->get_mesh()->bounding_box_tree();
+
+	i_ramo  = NULL;
+	i_rc    = NULL;
+	i_conv  = NULL;
+}
+// Reads values, initializes detector
+
+// Destructor
+TRACSInterface::~TRACSInterface()
+{
+//	delete i_ramo, i_rc, i_conv;
+}
+
+/*
+ * Convert i_total to TH1D
+ */
+TH1D * TRACSInterface::GetItRamo()
+{
+	if (i_ramo != NULL) 
+	{
+	}
+	else
+	{
+		i_ramo  = new TH1D("hnoconv","Ramo current",n_tSteps, 0.0, max_time);
+		// Compute time + format vectors for writting to file
+		for (int j=0; j < n_tSteps; j++)
+		{
+			i_ramo->SetBinContent(j+1, i_total[j] );
+		}
+	}
+		return i_ramo;
+}
+
+/*
+ * Convert i_total to TH1D after simulating simple RC circuit
+ */
+TH1D * TRACSInterface::GetItRc()
+{
+
+	if (i_rc != NULL) 
+	{
+	}
+	else
+	{
+		i_rc    = new TH1D("hnoconv","Ramo current",n_tSteps, 0.0, max_time);
+		std::valarray<double> i_shaped ((size_t) n_tSteps);	
+		double RC = 50.*C; // Ohms*Farad
+		double alfa = dt/(RC+dt);
+
+		for (int j = 1; j <n_tSteps; j++) 
+		{
+			i_shaped[j]=i_shaped[j-1]+alfa*(i_total[j]-i_shaped[j-1]);
+			i_rc->SetBinContent(j+1, i_shaped[j]);
+		}
+
+	}
+		return i_rc;
+}
+
+/*
+ * Convert i_total to TH1D after convolution with the amplifier TransferFunction
+ */
+TH1D * TRACSInterface::GetItConv()
+{
+	if (i_conv != NULL) 
+	{
+	}
+	else
+	{
+		i_conv  = new TH1D("hnoconv","Ramo current",n_tSteps, 0.0, max_time);
+		i_ramo = GetItRamo();
+		i_conv = H1DConvolution( i_ramo , C*1.e12 );
+	}
+		return i_conv;
+}
+
+/*
+ * Performs the simulation for all given carriers and stores the current in a valarray.
+ * No variable is returned. To get the current une must choose the apropiate Getter for 
+ * one's needs
+ */
+void TRACSInterface::simulate_ramo_current()
+{
+	i_rc = NULL;
+	i_ramo = NULL;
+	i_conv = NULL;
+	i_hole = 0;
+	i_elec = 0;
+	i_total = 0;
+
+	carrierCollection->simulate_drift( dt, max_time, yPos, zPos, i_elec, i_hole);
+
+	i_total = i_elec + i_hole;
+}
+
+void TRACSInterface::set_NeffParam(std::vector<double> newParam)
+{
+	if ( newParam.size() == 8)
+	{
+		neff_param.assign(std::begin(newParam), std::end(newParam));
+	}
+	else
+	{
+		std::cout << "Error setting up new Neff, incorrect number of parameters" << std::endl;
+	}
+
+	pDetector->set_neff_param(neff_param);
+}
+
+void TRACSInterface::set_trappingTime(double newTrapTime)
+{
+	if (newTrapTime > 0) 
+	{
+		trapping = newTrapTime;
+	}
+	else
+	{
+		std::cout << "Error setting up new Trapping Time, it must be a positive value" << std::endl;
+	}
+
+	pDetector->set_trapping_time(trapping);
+
+}
+
+void TRACSInterface::set_zPos(double newZPos)
+{
+	if (newZPos <= 0 && newZPos >= depth) 
+	{
+		std::cout << "Watch out! You probably set the laser out of the detector" << std::endl;
+	}
+	zPos = newZPos;
+}
+
+void TRACSInterface::set_yPos(double newYPos)
+{
+	if (std::abs(newYPos) > (2*nns+1)*pitch)
+	{
+		std::cout << "Watch out! You probably set the laser out of the detector" << std::endl;
+	}
+	yPos = newYPos;
+}
+
+void TRACSInterface::set_vBias(double newVBias)
+{
+	if (newVBias == vBias) 
+	{
+		std::cout << "The new Bias voltage is the same as the previous" << std::endl;
+	}
+	else
+	{
+		vBias = newVBias;
+	}
+	pDetector->set_voltages(vBias, vDepletion);
+}
+
+void TRACSInterface::set_fields()
+{
+	// Get detector ready
+	pDetector->solve_d_f_grad();
+	pDetector->solve_d_u();
+}
+

--- a/src/TRACSInterface.h
+++ b/src/TRACSInterface.h
@@ -1,3 +1,5 @@
+#ifndef TRACSINTERFACE_H
+#define TRACSINTERFACE_H
 #include "SMSDetector.h"
 #include "Source.h"
 #include "utilities.h"
@@ -6,15 +8,16 @@
 #include <TH1D.h> // 1 Dimesional ROOT histogram 
 #include <iterator>
 #include <limits>  // std::numeric_limits
+#include <cmath>
 #include <functional>
+
+extern TH1D *H1DConvolution( TH1D *htct, Double_t Cend=0. ) ; 
 
 class TRACSInterface
 {
 	private:
 
-		// Declaring external convolution function and threaded function
-		extern TH1D *H1DConvolution( TH1D *htct , Double_t Cend=0. ) ; 
-
+		// Declaring external convolution function 
 		double pitch; 
 		double width; 
 		double depth; 
@@ -24,46 +27,36 @@ class TRACSInterface
 		double C; 
 		double dt; 
 		double max_time; 
-		double v_bias; 
-		double vInit; 
-		double deltaV; 
-		double vMax; 
-		double v_depletion; 
-		double deltaZ; 
-		double zInit; 
-		double zMax = depth; 
-		double yInit; 
-		double yMax;
+		double vBias; 
+		double vDepletion; 
+		double zPos; 
+		double yPos; 
 
-		unsigned int nns; 
-		unsigned int n_cells_y; 
-		unsigned int n_cells_x; 
-		unsigned int waveLength; 
-		unsigned int n_vSteps; 
-		unsigned int n_zSteps; 
-		unsigned int n_ySteps; 
-		unsigned int n_tSteps;
+		int nns; 
+		int n_cells_y; 
+		int n_cells_x; 
+		int n_tSteps;
 
 		char bulk_type; 
 		char implant_type;
 
-		std::string scanType;
-		std::vector<double> neff_param;
+		std::vector<double> neff_param = {0};
+		std::valarray<double> i_total;
+		std::valarray<double> i_elec;
+		std::valarray<double> i_hole;
 
-		TH1D *hnoconv; 
-		TH1D *hconv; 
+		std::string carrierFile;
+
 		TH1D *i_ramo; 
 		TH1D *i_rc; 
 		TH1D *i_conv;
 
-		SMSDetector detector;
-
 		// Create carrier and observe movement
-		SMSDetector * dec_pointer;
+		SMSDetector * pDetector;
 
 		// get number of steps from time
 		QString filename;
-		CarrierCollection * carrier_collection;
+		CarrierCollection * carrierCollection;
 
 	public:
 
@@ -72,15 +65,17 @@ class TRACSInterface
 
 		// Destructor
 		~TRACSInterface();
-		TH1D GetItRamo();
-		TH1D GetItRc();
-		TH1D GetItConv();
-		void set_neffParam(std::vector<double> newParam);
+		TH1D *GetItRamo();
+		TH1D *GetItRc();
+		TH1D *GetItConv();
+		void simulate_ramo_current();
+		void set_NeffParam(std::vector<double> newParam);
 		void set_trappingTime(double newTrapTime);
 		void set_zPos(double newZPos);
 		void set_yPos(double newYPos);
 		void set_vBias(double newVBias);
+		void set_fields();
 		
-		
+};
 
-}
+#endif // TRACSINTERFACE_H

--- a/src/files2move2bin/Config.TRACS
+++ b/src/files2move2bin/Config.TRACS
@@ -140,9 +140,15 @@ Lambda = 1064   # In nm
 #   -edge-TCT: IR laser moved along Z-axis
 #   -top-TCT: Red laser, one shot at different voltages or scan on X-Y
 #   -bottom-TCT: Red laser, one shot at different voltages or scan on X-Y
-##################SCAN ON X-Y IS NOT IMPLEMENTED YET######################
+
 ScanType = edge   # edge/top/bottom
 
+# File where the carriers are stored. TRACS already provides carrier files 
+# for edge-TCT and TCT simulations but anyother file can be used, provided 
+# it has the same format. Here you should provide the path to the file 
+# to be used in the simulation. Relative path is set to the folder from 
+# which TRACS is executed.
+CarrierFile = etct.carriers
 
 #------------------------ ELECTRONICS SHAPING ----------------------------#
 
@@ -183,13 +189,7 @@ TotalTime = 1.5e-8   # in seconds ( ~10ns)
 # detector. These voltages include the depletion voltage as well as the 
 # various bias voltages that one may wish to apply to the detector.
 
-# Voltage applied to the detector in reverse mode (reverse bias) with 
-# respect to the natural voltage appearing in the detector due to p-n 
-# junction. This is a legacy value that will be eliminated as soon as we 
-# implement a loop to simulate different voltages at once.
-BiasVoltage = 350.   # in Volts # Still needed, should get rid of it later
-
-# Starting voltage for the simulation. One usually wishes that it is 
+# Starting bias voltage for the simulation. One usually wishes that it is 
 # higher than the depletion voltage for TRACS does not simulate thermal 
 # diffusion effects.
 InitialVoltage = 150 #volts

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,6 @@ int main()
 		   C = 0,
 		   dt = 0,
 		   max_time = 0,
-		   v_bias = 0,
 		   vInit = 0,
 		   deltaV = 0,
 		   vMax = 0,
@@ -76,7 +75,8 @@ int main()
 	std::string scanType = "defaultString";
 	std::vector<double> neff_param(8,0.);
 
-	utilities::parse_config_file("Config.TRACS", depth, width,  pitch, nns, temp, trapping, fluence, nThreads, n_cells_x, n_cells_y, bulk_type, implant_type, waveLength, scanType, C, dt, max_time, v_bias, vInit, deltaV, vMax, v_depletion, zInit, zMax, deltaZ, yInit, yMax, deltaY, neff_param);
+	std::string file_carriers = "etct.carriers";
+	utilities::parse_config_file("Config.TRACS", file_carriers, depth, width,  pitch, nns, temp, trapping, fluence, nThreads, n_cells_x, n_cells_y, bulk_type, implant_type, waveLength, scanType, C, dt, max_time, vInit, deltaV, vMax, v_depletion, zInit, zMax, deltaZ, yInit, yMax, deltaY, neff_param);
 	
 	// Create vector of (n-1) threads as the nth thread is the main thread
 	std::thread t[nThreads-1];
@@ -109,7 +109,7 @@ int main()
 	std::string stepY = std::to_string((int) std::floor(deltaY));
 	std::string cap = std::to_string((int) std::floor(C*1.e12));
 	//std::string z_step  = std::to_string((int) std::floor(deltaZ));
-	std::string voltage = std::to_string((int) std::floor(v_bias));
+	std::string voltage = std::to_string((int) std::floor(vInit));
 
 	parameters["allow_extrapolation"] = true;
 
@@ -124,7 +124,6 @@ int main()
 	// get number of steps from time
 	int n_tSteps = (int) std::floor(max_time / dt);
 
-	std::string file_carriers = "etct.carriers";
 	QString filename = "etct.carriers";
 	CarrierCollection * carrier_collection = new CarrierCollection(dec_pointer);
 

--- a/src/mainWindow.cpp
+++ b/src/mainWindow.cpp
@@ -33,6 +33,8 @@ MainWindow::MainWindow(QWidget *parent) :
   connect(ui->show_weighting_pot_3d_button, SIGNAL(clicked()), this, SLOT(show_weighting_potential_3d()));
   connect(ui->show_electric_pot_2d_button, SIGNAL(clicked()), this, SLOT(show_electric_potential_2d()));
   connect(ui->show_electric_pot_3d_button, SIGNAL(clicked()), this, SLOT(show_electric_potential_3d()));
+				  connect(ui->plot_neff_button, SIGNAL(clicked()), this, SLOT(show_carrier_map_line()));//show_custom_neff()));
+//				  when click on irrad_tab => z3 => setMaximum(depth) && setMinimum(depth)
 
   // currents tab connectors
   connect(ui->s_carrier_button, SIGNAL(clicked()),this, SLOT(drift_single_carrier()));
@@ -86,9 +88,25 @@ void MainWindow::solve_fem()
   char implant_type = ui->implant_type_combo_box->currentText().toStdString().c_str()[0];
   int n_cellsx = ui->n_cellsx_int_box->value();
   int n_cellsy = ui->n_cellsy_int_box->value();
+  double trapping = 1.e-9 * ui->trapping_double_box->value();
+			double fluence = 0;
+			std::vector<double> neff_param (8, 0);
+			
+			if (ui->fluence_chckbx->isChecked())
+			{
+				fluence = 1e14;
+				neff_param[0] = ui->y0_double_box->value();
+				neff_param[1] = ui->y1_double_box->value();
+				neff_param[2] = ui->y2_double_box->value();
+				neff_param[3] = ui->y3_double_box->value();
+				neff_param[4] = 0.0;
+				neff_param[5] = ui->z1_double_box->value();
+				neff_param[6] = ui->z2_double_box->value();
+				neff_param[7] = ui->depth_double_box->value();
+			}else{}
 
   ui->fem_progress_bar->setValue(10);
-  detector = new SMSDetector(pitch, width, depth, nns, bulk_type, implant_type, n_cellsx, n_cellsy, Temperature);
+  detector = new SMSDetector(pitch, width, depth, nns, bulk_type, implant_type, n_cellsx, n_cellsy, Temperature, trapping, fluence, neff_param);
 
   double v_bias = ui->bias_voltage_double_box->value();
   double v_depletion = ui->depletion_voltage_double_box->value();
@@ -967,6 +985,10 @@ void MainWindow::drift_carrier_collection()
      y_hole[i] = curr_hole[i];
      y_total[i] = curr_total[i];
   }
+
+  // here one show implement electronics shaping
+  // Call H1DConvolution
+  // convert to QVector
 
   // set new data
   ui->gen_carrier_curr_qcp->graph(0)->setData(x_elec, y_elec);

--- a/src/mainWindow.cpp
+++ b/src/mainWindow.cpp
@@ -67,6 +67,10 @@ MainWindow::MainWindow(QWidget *parent) :
   connect(ui->a_carrier_drift_button,  SIGNAL(clicked()), this, SLOT(drift_carrier_collection()));
   connect(ui->save_results_carriers,  SIGNAL(clicked()), this, SLOT(save_results_raw()));
 
+  // full simulation tab connectors
+
+//  connect(ui->neff_map2,  SIGNAL(clicked()), this, SLOT(plot_custom_neff_FS()));
+
 }
 
 MainWindow::~MainWindow()
@@ -236,7 +240,55 @@ void MainWindow::show_carrier_map_qcp()
   ui->carrier_map_qcp->rescaleAxes();
   ui->carrier_map_qcp->replot();
 }
-
+//
+//void MainWindow::plot_custom_neff_FS()
+//{
+//  // get data from ui
+//  double y0 = ui->y0_double_box_FS->value();
+//  double y1 = ui->y1_double_box_FS->value();
+//  double y2 = ui->y2_double_box_FS->value();
+//  double y3 = ui->y3_double_box_FS->value();
+//  double z0 = 0.0;
+//  double z1 = ui->z1_double_box_FS->value();
+//  double z2 = ui->z2_double_box_FS->value();
+//  double z3 = detector->get_depth();
+//
+//  unsigned int vectorSize = 500;
+//QVector<double> x(vectorSize), y(vectorSize);
+//double deltaX = (detector->get_depth())/(vectorSize-1);
+//x[0] = 0.0; 
+//y[0] = y0;
+//
+////Intermediate variable (who cares about performance when using the GUI?)
+//double neff_1, neff_2, neff_3, bridge_1, bridge_2, bridge_3;
+//
+//for(unsigned int i = 1; i < vectorSize; i++)
+//{
+//	x[i] = x[i-1] + deltaX;
+//
+//	neff_1 = ((y0-y1)/(z0-z1))*(x[i]-z0) + y0;
+//	neff_2 = ((y1-y2)/(z1-z2))*(x[i]-z1) + y1;
+//	neff_3 = ((y2-y3)/(z2-z3))*(x[i]-z2) + y2;
+//
+//	// For continuity and smoothness purposes
+//	bridge_1 = tanh(1000*(x[i]-z0)) - tanh(1000*(x[i]-z1));
+//	bridge_2 = tanh(1000*(x[i]-z1)) - tanh(1000*(x[i]-z2));
+//	bridge_3 = tanh(1000*(x[i]-z2)) - tanh(1000*(x[i]-z3));
+//
+//	y[i] = 0.5*(neff_1*bridge_1)+(neff_2*bridge_2)+(neff_3*bridge_3);
+//}
+//ui->neff_map_2->addGraph();
+//ui->neff_map_2->graph(0)->setData(x, y);
+//// give the axes some labels:
+// ui->neff_map_2->xAxis->setLabel("z/um");
+// ui->neff_map_2->yAxis->setLabel("Neff(z)");
+// // set axes ranges, so we see all data:
+// ui->neff_map_2->xAxis->setRange(z0, z3);
+// ui->neff_map_2->yAxis->setRange(y0, y3);
+// ui->neff_map_2->replot();
+// ui->neff_map_2->setInteractions(QCP::iRangeDrag | QCP::iRangeZoom | QCP::iSelectPlottables);
+//}
+//
 void MainWindow::plot_custom_neff()
 {
   // get data from ui
@@ -271,7 +323,7 @@ for(unsigned int i = 1; i < vectorSize; i++)
 	bridge_2 = tanh(1000*(x[i]-z1)) - tanh(1000*(x[i]-z2));
 	bridge_3 = tanh(1000*(x[i]-z2)) - tanh(1000*(x[i]-z3));
 
-	y[i] = 0.5*(neff_1*bridge_1)+(neff_2*bridge_2)+(neff_3*bridge_3);
+	y[i] = 0.5*((neff_1*bridge_1)+(neff_2*bridge_2)+(neff_3*bridge_3));
 }
 ui->neff_map->addGraph();
 ui->neff_map->graph(0)->setData(x, y);

--- a/src/mainWindow.h
+++ b/src/mainWindow.h
@@ -43,6 +43,8 @@ private slots:
     void show_weighting_potential_3d();
     void show_electric_potential_2d();
     void show_electric_potential_3d();
+	void plot_custom_neff();
+	void plot_custom_neff_bg();
 
     // fields tab
     void show_w_field_mod_map();

--- a/src/mainWindow.h
+++ b/src/mainWindow.h
@@ -44,7 +44,6 @@ private slots:
     void show_electric_potential_2d();
     void show_electric_potential_3d();
 	void plot_custom_neff();
-	void plot_custom_neff_bg();
 
     // fields tab
     void show_w_field_mod_map();

--- a/src/mainWindow.ui
+++ b/src/mainWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1063</width>
-    <height>759</height>
+    <width>1221</width>
+    <height>825</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,355 +30,713 @@
        <attribute name="title">
         <string>Potentials</string>
        </attribute>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="2" column="0">
-         <widget class="QCustomPlot" name="electric_pot_qcp" native="true">
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QGroupBox" name="detector_properties_layout">
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="title">
-           <string>DETECTOR PROPERTIES</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <item row="5" column="1">
-            <widget class="QDoubleSpinBox" name="depletion_voltage_double_box">
-             <property name="maximum">
-              <double>9999.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>250.00000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0">
-      	    <widget class="QLabel" name="temperature_label">
-             <property name="text">
-              <string>Temperature</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <widget class="QDoubleSpinBox" name="Temperature_double_box">
-             <property name="maximum">
-              <double>9999.000000000000000</double>
-             </property>
-             <property name="minimum">
-              <double>0.000000000000000000</double>
-             </property>
-             <property name="value">
-              <double>300.00000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="width_label">
-             <property name="text">
-              <string>Width</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QDoubleSpinBox" name="depth_double_box">
-             <property name="maximum">
-              <double>10000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>300.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="depletion_voltage_label">
-             <property name="text">
-              <string>Depletion Voltage</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QDoubleSpinBox" name="width_double_box">
-             <property name="maximum">
-              <double>100000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>25.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="depth_label">
-             <property name="text">
-              <string>Depth</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="bulk_type_label">
-             <property name="text">
-              <string>Bulk Type</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="pitch_label">
-             <property name="text">
-              <string>Pitch</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QDoubleSpinBox" name="pitch_double_box">
-             <property name="maximum">
-              <double>100000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>80.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QComboBox" name="bulk_type_combo_box">
-             <item>
-              <property name="text">
-               <string>p</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>n</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="implant_type_label">
-             <property name="text">
-              <string>Implant Type</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QComboBox" name="implant_type_combo_box">
-             <item>
-              <property name="text">
-               <string>n</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>p</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QGroupBox" name="other_conf_layout">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="title">
-           <string>ADDITIONAL CONFIGURATION</string>
-          </property>
-          <layout class="QFormLayout" name="formLayout">
-           <property name="fieldGrowthPolicy">
-            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       <widget class="QWidget" name="layoutWidget">
+        <property name="geometry">
+         <rect>
+          <x>750</x>
+          <y>10</y>
+          <width>451</width>
+          <height>721</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_11">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetNoConstraint</enum>
+         </property>
+         <item row="1" column="0">
+          <widget class="QGroupBox" name="other_conf_layout">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <item row="0" column="0">
-            <widget class="QLabel" name="bias_voltage_label">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="title">
+            <string>ADDITIONAL CONFIGURATION</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="4" column="1">
+             <widget class="QProgressBar" name="fem_progress_bar">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="QPushButton" name="solve_fem_button">
+              <property name="text">
+               <string>Solve FEM Problem</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLabel" name="show_weighting_pot_label">
+              <property name="text">
+               <string>Weighting Potential</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="bias_voltage_label">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Bias Voltage (V)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="n_cellsx_label">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string># Cells X</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="n_cellsy_label">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string># Cells Y</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="2">
+             <widget class="QSpinBox" name="n_cellsy_int_box">
+              <property name="maximum">
+               <number>10000</number>
+              </property>
+              <property name="value">
+               <number>150</number>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="2">
+             <layout class="QHBoxLayout" name="show_electric_pot_buttons">
+              <item>
+               <widget class="QPushButton" name="show_electric_pot_2d_button">
+                <property name="text">
+                 <string>Show 2D</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="show_electric_pot_3d_button">
+                <property name="text">
+                 <string>Show 3D</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="2">
+             <widget class="QDoubleSpinBox" name="bias_voltage_double_box">
+              <property name="maximum">
+               <double>1000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>260.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLabel" name="nn_strips_label">
+              <property name="text">
+               <string>Neighbour Strips</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="2">
+             <layout class="QHBoxLayout" name="show_weighting_pot_buttons">
+              <item>
+               <widget class="QPushButton" name="show_weighting_pot_2d_button">
+                <property name="text">
+                 <string>Show 2D</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="show_weighting_pot_3d_button">
+                <property name="text">
+                 <string>Show 3D</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="2" column="2">
+             <widget class="QSpinBox" name="n_cellsx_int_box">
+              <property name="maximum">
+               <number>10000</number>
+              </property>
+              <property name="value">
+               <number>150</number>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLabel" name="show_electric_pot_label">
+              <property name="text">
+               <string>Electric Potential</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QSpinBox" name="nn_strips_int_box">
+              <property name="maximum">
+               <number>10</number>
+              </property>
+              <property name="value">
+               <number>2</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QTabWidget" name="potentials_miniTab">
+           <property name="currentIndex">
+            <number>1</number>
+           </property>
+           <widget class="QWidget" name="noIrrad_tab">
+            <attribute name="title">
+             <string>Non Irradiated</string>
+            </attribute>
+            <widget class="QGroupBox" name="detector_properties_layout">
+             <property name="geometry">
+              <rect>
+               <x>10</x>
+               <y>10</y>
+               <width>331</width>
+               <height>311</height>
+              </rect>
+             </property>
              <property name="font">
               <font>
+               <pointsize>9</pointsize>
                <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
-             <property name="text">
-              <string>Bias Voltage</string>
+             <property name="title">
+              <string>DETECTOR PROPERTIES</string>
              </property>
+             <layout class="QGridLayout" name="gridLayout_2">
+              <item row="0" column="1">
+               <widget class="QDoubleSpinBox" name="pitch_double_box">
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>80.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="QDoubleSpinBox" name="depletion_voltage_double_box">
+                <property name="maximum">
+                 <double>9999.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>250.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0">
+               <widget class="QLabel" name="temperature_label">
+                <property name="text">
+                 <string>Temperature (K)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="1">
+               <widget class="QDoubleSpinBox" name="Temperature_double_box">
+                <property name="minimum">
+                 <double>0.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>9999.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>300.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="width_label">
+                <property name="text">
+                 <string>Width (um)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="depth_double_box">
+                <property name="maximum">
+                 <double>10000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>300.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="depletion_voltage_label">
+                <property name="text">
+                 <string>Depletion Voltage (V)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="width_double_box">
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>25.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="depth_label">
+                <property name="text">
+                 <string>Depth (um)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="bulk_type_label">
+                <property name="text">
+                 <string>Bulk Type</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="pitch_label">
+                <property name="text">
+                 <string>Pitch (um)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QComboBox" name="bulk_type_combo_box">
+                <item>
+                 <property name="text">
+                  <string>p</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>n</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="implant_type_label">
+                <property name="text">
+                 <string>Implant Type</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QComboBox" name="implant_type_combo_box">
+                <item>
+                 <property name="text">
+                  <string>n</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>p</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+             </layout>
+             <zorder>depletion_voltage_double_box</zorder>
+             <zorder>Temperature_double_box</zorder>
+             <zorder>width_label</zorder>
+             <zorder>depth_double_box</zorder>
+             <zorder>depletion_voltage_label</zorder>
+             <zorder>width_double_box</zorder>
+             <zorder>depth_label</zorder>
+             <zorder>bulk_type_label</zorder>
+             <zorder>pitch_label</zorder>
+             <zorder>pitch_double_box</zorder>
+             <zorder>bulk_type_combo_box</zorder>
+             <zorder>implant_type_label</zorder>
+             <zorder>implant_type_combo_box</zorder>
+             <zorder>temperature_label</zorder>
             </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QDoubleSpinBox" name="bias_voltage_double_box">
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>260.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="nn_strips_label">
-             <property name="text">
-              <string>Neighbour Strips</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QSpinBox" name="nn_strips_int_box">
-             <property name="maximum">
-              <number>10</number>
-             </property>
-             <property name="value">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="n_cellsx_label">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string># Cells X</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QSpinBox" name="n_cellsx_int_box">
-             <property name="maximum">
-              <number>10000</number>
-             </property>
-             <property name="value">
-              <number>150</number>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="n_cellsy_label">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string># Cells Y</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QSpinBox" name="n_cellsy_int_box">
-             <property name="maximum">
-              <number>10000</number>
-             </property>
-             <property name="value">
-              <number>150</number>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0">
-            <widget class="QProgressBar" name="fem_progress_bar">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <widget class="QPushButton" name="solve_fem_button">
-             <property name="text">
-              <string>Solve FEM Problem</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="1">
-            <layout class="QHBoxLayout" name="show_weighting_pot_buttons">
-             <item>
-              <widget class="QPushButton" name="show_weighting_pot_2d_button">
+           </widget>
+           <widget class="QWidget" name="irrad_tab">
+            <attribute name="title">
+             <string>Irradiated</string>
+            </attribute>
+            <layout class="QGridLayout" name="gridLayout_18">
+             <item row="5" column="1">
+              <widget class="QPushButton" name="plot_neff_button">
+               <property name="layoutDirection">
+                <enum>Qt::LeftToRight</enum>
+               </property>
                <property name="text">
-                <string>Show 2D</string>
+                <string>Plot 
+ 
+
+ Neff</string>
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QPushButton" name="show_weighting_pot_3d_button">
+             <item row="4" column="0" colspan="2">
+              <layout class="QGridLayout" name="gridLayout_9">
+               <item row="0" column="0">
+                <widget class="QLabel" name="pitch_label_2">
+                 <property name="text">
+                  <string>z0</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="width_label_2">
+                 <property name="text">
+                  <string>z1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QLabel" name="depletion_voltage_label_2">
+                 <property name="layoutDirection">
+                  <enum>Qt::LeftToRight</enum>
+                 </property>
+                 <property name="text">
+                  <string>z2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <widget class="QLabel" name="width_label_4">
+                 <property name="text">
+                  <string>z3</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QDoubleSpinBox" name="z0_double_box">
+                 <property name="decimals">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <double>0.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>0.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QDoubleSpinBox" name="z1_double_box">
+                 <property name="decimals">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <double>100000.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>120.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QDoubleSpinBox" name="z2_double_box">
+                 <property name="decimals">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <double>9999.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>220.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QDoubleSpinBox" name="z3_double_box">
+                 <property name="decimals">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <double>100000.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>300.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="pitch_label_3">
+                 <property name="text">
+                  <string>y0</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="width_label_3">
+                 <property name="text">
+                  <string>y1</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QLabel" name="depletion_voltage_label_3">
+                 <property name="layoutDirection">
+                  <enum>Qt::LeftToRight</enum>
+                 </property>
+                 <property name="text">
+                  <string>y2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="3">
+                <widget class="QLabel" name="width_label_5">
+                 <property name="text">
+                  <string>y3</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QDoubleSpinBox" name="y0_double_box">
+                 <property name="decimals">
+                  <number>3</number>
+                 </property>
+                 <property name="minimum">
+                  <double>-10000.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>10000.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>-25.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QDoubleSpinBox" name="y1_double_box">
+                 <property name="decimals">
+                  <number>3</number>
+                 </property>
+                 <property name="minimum">
+                  <double>-1000.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>1000.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>0.020000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="2">
+                <widget class="QDoubleSpinBox" name="y2_double_box">
+                 <property name="decimals">
+                  <number>3</number>
+                 </property>
+                 <property name="minimum">
+                  <double>-100.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>100.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>0.220000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="3">
+                <widget class="QDoubleSpinBox" name="y3_double_box">
+                 <property name="decimals">
+                  <number>3</number>
+                 </property>
+                 <property name="minimum">
+                  <double>-100.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>100.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>33.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="1" column="0">
+              <widget class="QCheckBox" name="fluence_chckbx">
                <property name="text">
-                <string>Show 3D</string>
+                <string>Irradiation</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+               <property name="tristate">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0" colspan="2">
+              <layout class="QGridLayout" name="gridLayout_17">
+               <item row="0" column="0">
+                <widget class="QLabel" name="trappingTime_label">
+                 <property name="text">
+                  <string>Trapping Time (ns)</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QDoubleSpinBox" name="trapping_double_box">
+                 <property name="decimals">
+                  <number>2</number>
+                 </property>
+                 <property name="minimum">
+                  <double>0.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>2000.000000000000000</double>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.000001000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>3.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="5" column="0">
+              <widget class="QCustomPlot" name="neff_map" native="true">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="rad_param_text">
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Sunken</enum>
+               </property>
+               <property name="lineWidth">
+                <number>2</number>
+               </property>
+               <property name="text">
+                <string>RADIATION PARAMETERS</string>
+               </property>
+               <property name="textFormat">
+                <enum>Qt::PlainText</enum>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::NoTextInteraction</set>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="trappingTime_label_2">
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="layoutDirection">
+                <enum>Qt::LeftToRight</enum>
+               </property>
+               <property name="text">
+                <string>          Custom Neff Parametrization</string>
                </property>
               </widget>
              </item>
             </layout>
-           </item>
-           <item row="10" column="1">
-            <layout class="QHBoxLayout" name="show_electric_pot_buttons">
-             <item>
-              <widget class="QPushButton" name="show_electric_pot_2d_button">
-               <property name="text">
-                <string>Show 2D</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="show_electric_pot_3d_button">
-               <property name="text">
-                <string>Show 3D</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item row="10" column="0">
-            <widget class="QLabel" name="show_electric_pot_label">
-             <property name="text">
-              <string>Electric Potential</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="show_weighting_pot_label">
-             <property name="text">
-              <string>Weighting Potential</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QCustomPlot" name="weighting_pot_qcp" native="true">
-          <property name="minimumSize">
-           <size>
-            <width>300</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
+           </widget>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="layoutWidget">
+        <property name="geometry">
+         <rect>
+          <x>9</x>
+          <y>9</y>
+          <width>731</width>
+          <height>721</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_10">
+         <item row="0" column="0">
+          <widget class="QCustomPlot" name="weighting_pot_qcp" native="true">
+           <property name="minimumSize">
+            <size>
+             <width>300</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCustomPlot" name="electric_pot_qcp" native="true">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
       <widget class="QWidget" name="fields_tab">
        <property name="enabled">
@@ -1159,6 +1517,13 @@
                </item>
               </layout>
              </item>
+             <item alignment="Qt::AlignHCenter">
+              <widget class="QCheckBox" name="rc_checkbox">
+               <property name="text">
+                <string>Electronics shaping</string>
+               </property>
+              </widget>
+             </item>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_9">
                <item>
@@ -1191,6 +1556,870 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="tab">
+       <attribute name="title">
+        <string>Full Simulation</string>
+       </attribute>
+       <widget class="QWidget" name="layoutWidget">
+        <property name="geometry">
+         <rect>
+          <x>409</x>
+          <y>9</y>
+          <width>481</width>
+          <height>661</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_13">
+         <item row="1" column="0" colspan="2">
+          <widget class="QCustomPlot" name="gen_carrier_map_qcp_2" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QPushButton" name="open_carriers_file_2">
+           <property name="text">
+            <string>Open File</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0" colspan="2">
+          <widget class="QCustomPlot" name="neff_map_2" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0" colspan="2">
+          <widget class="QPushButton" name="pushButton_2">
+           <property name="font">
+            <font>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LeftToRight</enum>
+           </property>
+           <property name="text">
+            <string>Plot Neff</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QPushButton" name="load_carriers_button_2">
+           <property name="text">
+            <string>Load File</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" rowspan="2">
+          <widget class="QLineEdit" name="filename_display_2"/>
+         </item>
+         <item row="0" column="0" colspan="2">
+          <widget class="QLabel" name="rad_param_text_3">
+           <property name="font">
+            <font>
+             <pointsize>13</pointsize>
+             <weight>50</weight>
+             <bold>false</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="lineWidth">
+            <number>2</number>
+           </property>
+           <property name="text">
+            <string>Laser Beem Visualization Tool</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::NoTextInteraction</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="2">
+          <widget class="QLabel" name="rad_param_text_4">
+           <property name="font">
+            <font>
+             <pointsize>13</pointsize>
+             <weight>50</weight>
+             <bold>false</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="lineWidth">
+            <number>2</number>
+           </property>
+           <property name="text">
+            <string> Custom Neff Visualization Tool</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::NoTextInteraction</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="layoutWidget">
+        <property name="geometry">
+         <rect>
+          <x>890</x>
+          <y>9</y>
+          <width>220</width>
+          <height>427</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_12">
+         <item row="0" column="0">
+          <widget class="QGroupBox" name="detector_properties_layout_3">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="title">
+            <string>LOOP PARAMETERS [Z-axis]</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_6">
+            <item row="0" column="0">
+             <widget class="QLabel" name="pitch_label_7">
+              <property name="text">
+               <string>Initial Position</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QDoubleSpinBox" name="depth_double_box_3">
+              <property name="maximum">
+               <double>10000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>300.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="depth_label_3">
+              <property name="text">
+               <string>Step</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="pitch_double_box_7">
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>80.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="width_label_11">
+              <property name="text">
+               <string>Final Position</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QDoubleSpinBox" name="width_double_box_11">
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>25.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QGroupBox" name="detector_properties_layout_5">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="title">
+            <string>LOOP PARAMETERS [Y-axis]</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_8">
+            <item row="0" column="0">
+             <widget class="QLabel" name="pitch_label_9">
+              <property name="text">
+               <string>Initial Position</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QDoubleSpinBox" name="depth_double_box_5">
+              <property name="maximum">
+               <double>10000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>300.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="depth_label_5">
+              <property name="text">
+               <string>Step</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="pitch_double_box_9">
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>80.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="width_label_13">
+              <property name="text">
+               <string>Final Position</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QDoubleSpinBox" name="width_double_box_13">
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>25.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QGroupBox" name="detector_properties_layout_4">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="title">
+            <string>LOOP PARAMETERS [Voltages]</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_7">
+            <item row="0" column="0">
+             <widget class="QLabel" name="pitch_label_8">
+              <property name="text">
+               <string>Initial Position</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QDoubleSpinBox" name="depth_double_box_4">
+              <property name="maximum">
+               <double>10000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>300.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="depth_label_4">
+              <property name="text">
+               <string>Step</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="pitch_double_box_8">
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>80.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="width_label_12">
+              <property name="text">
+               <string>Final Position</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QDoubleSpinBox" name="width_double_box_12">
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>25.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QPushButton" name="pushButton_3">
+           <property name="text">
+            <string>Run Full Simulation</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="layoutWidget">
+        <property name="geometry">
+         <rect>
+          <x>9</x>
+          <y>9</y>
+          <width>396</width>
+          <height>651</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_15">
+         <item row="0" column="0">
+          <widget class="QGroupBox" name="detector_properties_layout_2">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="title">
+            <string>DETECTOR PROPERTIES</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_5">
+            <item row="2" column="1">
+             <widget class="QDoubleSpinBox" name="depth_double_box_2">
+              <property name="maximum">
+               <double>10000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>300.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="pitch_label_4">
+              <property name="text">
+               <string>Pitch (um)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QComboBox" name="bulk_type_combo_box_2">
+              <item>
+               <property name="text">
+                <string>p</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>n</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="bulk_type_label_2">
+              <property name="text">
+               <string>Bulk Type</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0">
+             <widget class="QLabel" name="temperature_label_2">
+              <property name="text">
+               <string>Temperature (K)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="width_label_6">
+              <property name="text">
+               <string>Width (um)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QDoubleSpinBox" name="Temperature_double_box_2">
+              <property name="minimum">
+               <double>0.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>9999.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>300.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="depletion_voltage_label_4">
+              <property name="text">
+               <string>Depletion Voltage (V)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QComboBox" name="implant_type_combo_box_2">
+              <item>
+               <property name="text">
+                <string>n</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>p</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="depth_label_2">
+              <property name="text">
+               <string>Depth (um)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="pitch_double_box_4">
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>80.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="implant_type_label_2">
+              <property name="text">
+               <string>Implant Type</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QDoubleSpinBox" name="width_double_box_6">
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>25.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_4">
+              <property name="maximum">
+               <double>9999.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>250.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <layout class="QGridLayout" name="gridLayout_14">
+           <item row="0" column="0" colspan="2">
+            <widget class="QLabel" name="rad_param_text_2">
+             <property name="font">
+              <font>
+               <pointsize>9</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Sunken</enum>
+             </property>
+             <property name="lineWidth">
+              <number>2</number>
+             </property>
+             <property name="text">
+              <string>RADIATION PARAMETERS</string>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::PlainText</enum>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::NoTextInteraction</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1" colspan="2">
+            <widget class="QCheckBox" name="checkBox_2">
+             <property name="text">
+              <string>Irradiation</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QLabel" name="trappingTime_label_3">
+             <property name="text">
+              <string>Trapping Time (ns)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3">
+            <widget class="QDoubleSpinBox" name="trapping_double_box_3">
+             <property name="decimals">
+              <number>2</number>
+             </property>
+             <property name="minimum">
+              <double>0.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>2000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.000001000000000</double>
+             </property>
+             <property name="value">
+              <double>3.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0" colspan="3">
+            <widget class="QLabel" name="trappingTime_label_4">
+             <property name="font">
+              <font>
+               <pointsize>9</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>          Custom Neff Parametrization</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="pitch_label_5">
+             <property name="text">
+              <string>z0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLabel" name="width_label_7">
+             <property name="text">
+              <string>z1</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="2">
+            <widget class="QLabel" name="depletion_voltage_label_5">
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>z2</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="3">
+            <widget class="QLabel" name="width_label_8">
+             <property name="text">
+              <string>z3</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QDoubleSpinBox" name="pitch_double_box_5">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>0.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>0.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QDoubleSpinBox" name="width_double_box_7">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>100000.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>25.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="2">
+            <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_5">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>9999.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>25.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="3">
+            <widget class="QDoubleSpinBox" name="width_double_box_8">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>100000.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>25.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="pitch_label_6">
+             <property name="text">
+              <string>y0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QLabel" name="width_label_9">
+             <property name="text">
+              <string>y1</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="2">
+            <widget class="QLabel" name="depletion_voltage_label_6">
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>y2</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="3">
+            <widget class="QLabel" name="width_label_10">
+             <property name="text">
+              <string>y3</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QDoubleSpinBox" name="pitch_double_box_6">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>100000.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>80.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <widget class="QDoubleSpinBox" name="width_double_box_10">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>100000.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>25.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="2">
+            <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_6">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>9999.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>25.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="3">
+            <widget class="QDoubleSpinBox" name="width_double_box_9">
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <double>100000.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>25.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="0">
+          <widget class="QGroupBox" name="other_conf_layout_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="title">
+            <string>ADDITIONAL CONFIGURATION</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_16">
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="bias_voltage_double_box_2">
+              <property name="maximum">
+               <double>1000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>260.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QSpinBox" name="n_cellsy_int_box_2">
+              <property name="maximum">
+               <number>10000</number>
+              </property>
+              <property name="value">
+               <number>150</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="nn_strips_int_box_2">
+              <property name="maximum">
+               <number>10</number>
+              </property>
+              <property name="value">
+               <number>2</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="n_cellsx_label_2">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string># Cells X</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="nn_strips_label_2">
+              <property name="text">
+               <string>Neighbour Strips</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QSpinBox" name="n_cellsx_int_box_2">
+              <property name="maximum">
+               <number>10000</number>
+              </property>
+              <property name="value">
+               <number>150</number>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="bias_voltage_label_2">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Bias Voltage (V)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="n_cellsy_label_2">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string># Cells Y</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
      </widget>
     </item>
    </layout>
@@ -1200,8 +2429,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1063</width>
-     <height>23</height>
+     <width>1221</width>
+     <height>27</height>
     </rect>
    </property>
   </widget>

--- a/src/mainWindow.ui
+++ b/src/mainWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1221</width>
-    <height>825</height>
+    <width>1236</width>
+    <height>850</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,7 +18,7 @@
     <item>
      <widget class="QTabWidget" name="tabs">
       <property name="currentIndex">
-       <number>0</number>
+       <number>4</number>
       </property>
       <property name="usesScrollButtons">
        <bool>true</bool>
@@ -30,713 +30,718 @@
        <attribute name="title">
         <string>Potentials</string>
        </attribute>
-       <widget class="QWidget" name="layoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>750</x>
-          <y>10</y>
-          <width>451</width>
-          <height>721</height>
-         </rect>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_11">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetNoConstraint</enum>
-         </property>
-         <item row="1" column="0">
-          <widget class="QGroupBox" name="other_conf_layout">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>ADDITIONAL CONFIGURATION</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout">
-            <item row="4" column="1">
-             <widget class="QProgressBar" name="fem_progress_bar">
+       <layout class="QGridLayout" name="gridLayout_11">
+        <item row="0" column="1">
+         <widget class="QTabWidget" name="potentials_miniTab">
+          <property name="minimumSize">
+           <size>
+            <width>400</width>
+            <height>400</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>400</width>
+            <height>500</height>
+           </size>
+          </property>
+          <property name="currentIndex">
+           <number>1</number>
+          </property>
+          <widget class="QWidget" name="noIrrad_tab">
+           <attribute name="title">
+            <string>Non Irradiated</string>
+           </attribute>
+           <widget class="QGroupBox" name="detector_properties_layout">
+            <property name="geometry">
+             <rect>
+              <x>10</x>
+              <y>10</y>
+              <width>331</width>
+              <height>311</height>
+             </rect>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>DETECTOR PROPERTIES</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_2">
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="pitch_double_box">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>80.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QDoubleSpinBox" name="depletion_voltage_double_box">
+               <property name="maximum">
+                <double>9999.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>250.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="0">
+              <widget class="QLabel" name="temperature_label">
+               <property name="text">
+                <string>Temperature (K)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QDoubleSpinBox" name="Temperature_double_box">
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>9999.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>300.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="width_label">
+               <property name="text">
+                <string>Width (um)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="depth_double_box">
+               <property name="maximum">
+                <double>10000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>300.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="depletion_voltage_label">
+               <property name="text">
+                <string>Depletion Voltage (V)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="width_double_box">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>25.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="depth_label">
+               <property name="text">
+                <string>Depth (um)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="bulk_type_label">
+               <property name="text">
+                <string>Bulk Type</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="pitch_label">
+               <property name="text">
+                <string>Pitch (um)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QComboBox" name="bulk_type_combo_box">
+               <item>
+                <property name="text">
+                 <string>p</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>n</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="implant_type_label">
+               <property name="text">
+                <string>Implant Type</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QComboBox" name="implant_type_combo_box">
+               <item>
+                <property name="text">
+                 <string>n</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>p</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+            </layout>
+            <zorder>depletion_voltage_double_box</zorder>
+            <zorder>Temperature_double_box</zorder>
+            <zorder>width_label</zorder>
+            <zorder>depth_double_box</zorder>
+            <zorder>depletion_voltage_label</zorder>
+            <zorder>width_double_box</zorder>
+            <zorder>depth_label</zorder>
+            <zorder>bulk_type_label</zorder>
+            <zorder>pitch_label</zorder>
+            <zorder>pitch_double_box</zorder>
+            <zorder>bulk_type_combo_box</zorder>
+            <zorder>implant_type_label</zorder>
+            <zorder>implant_type_combo_box</zorder>
+            <zorder>temperature_label</zorder>
+           </widget>
+          </widget>
+          <widget class="QWidget" name="irrad_tab">
+           <attribute name="title">
+            <string>Irradiated</string>
+           </attribute>
+           <layout class="QGridLayout" name="gridLayout_18">
+            <item row="5" column="1">
+             <widget class="QPushButton" name="plot_neff_button">
+              <property name="layoutDirection">
+               <enum>Qt::LeftToRight</enum>
+              </property>
+              <property name="text">
+               <string>Plot 
+ 
+
+ Neff</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0" colspan="2">
+             <layout class="QGridLayout" name="gridLayout_9">
+              <item row="0" column="0">
+               <widget class="QLabel" name="pitch_label_2">
+                <property name="text">
+                 <string>z0</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="width_label_2">
+                <property name="text">
+                 <string>z1</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="depletion_voltage_label_2">
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="text">
+                 <string>z2</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QLabel" name="width_label_4">
+                <property name="text">
+                 <string>z3</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QDoubleSpinBox" name="z0_double_box">
+                <property name="decimals">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <double>0.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="z1_double_box">
+                <property name="decimals">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>120.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QDoubleSpinBox" name="z2_double_box">
+                <property name="decimals">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <double>9999.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>220.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QDoubleSpinBox" name="z3_double_box">
+                <property name="decimals">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>300.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="pitch_label_3">
+                <property name="text">
+                 <string>y0</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLabel" name="width_label_3">
+                <property name="text">
+                 <string>y1</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QLabel" name="depletion_voltage_label_3">
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="text">
+                 <string>y2</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="QLabel" name="width_label_5">
+                <property name="text">
+                 <string>y3</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QDoubleSpinBox" name="y0_double_box">
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="minimum">
+                 <double>-10000.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>10000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>-25.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QDoubleSpinBox" name="y1_double_box">
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="minimum">
+                 <double>-1000.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>1000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.020000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QDoubleSpinBox" name="y2_double_box">
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="minimum">
+                 <double>-100.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.220000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="QDoubleSpinBox" name="y3_double_box">
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="minimum">
+                 <double>-100.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>33.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="fluence_chckbx">
+              <property name="text">
+               <string>Irradiation</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <property name="tristate">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <layout class="QGridLayout" name="gridLayout_17">
+              <item row="0" column="0">
+               <widget class="QLabel" name="trappingTime_label">
+                <property name="text">
+                 <string>Trapping Time (ns)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QDoubleSpinBox" name="trapping_double_box">
+                <property name="decimals">
+                 <number>2</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>2000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.000001000000000</double>
+                </property>
+                <property name="value">
+                 <double>3.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="5" column="0">
+             <widget class="QCustomPlot" name="neff_map" native="true">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="value">
-               <number>0</number>
-              </property>
              </widget>
             </item>
-            <item row="4" column="2">
-             <widget class="QPushButton" name="solve_fem_button">
-              <property name="text">
-               <string>Solve FEM Problem</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="1">
-             <widget class="QLabel" name="show_weighting_pot_label">
-              <property name="text">
-               <string>Weighting Potential</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="bias_voltage_label">
+            <item row="0" column="0">
+             <widget class="QLabel" name="rad_param_text">
               <property name="font">
                <font>
+                <pointsize>9</pointsize>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
               </property>
-              <property name="text">
-               <string>Bias Voltage (V)</string>
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
               </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLabel" name="n_cellsx_label">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
+              <property name="frameShadow">
+               <enum>QFrame::Sunken</enum>
               </property>
-              <property name="text">
-               <string># Cells X</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QLabel" name="n_cellsy_label">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string># Cells Y</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="2">
-             <widget class="QSpinBox" name="n_cellsy_int_box">
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-              <property name="value">
-               <number>150</number>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="2">
-             <layout class="QHBoxLayout" name="show_electric_pot_buttons">
-              <item>
-               <widget class="QPushButton" name="show_electric_pot_2d_button">
-                <property name="text">
-                 <string>Show 2D</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="show_electric_pot_3d_button">
-                <property name="text">
-                 <string>Show 3D</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="0" column="2">
-             <widget class="QDoubleSpinBox" name="bias_voltage_double_box">
-              <property name="maximum">
-               <double>1000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>260.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="nn_strips_label">
-              <property name="text">
-               <string>Neighbour Strips</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="2">
-             <layout class="QHBoxLayout" name="show_weighting_pot_buttons">
-              <item>
-               <widget class="QPushButton" name="show_weighting_pot_2d_button">
-                <property name="text">
-                 <string>Show 2D</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="show_weighting_pot_3d_button">
-                <property name="text">
-                 <string>Show 3D</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="2">
-             <widget class="QSpinBox" name="n_cellsx_int_box">
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-              <property name="value">
-               <number>150</number>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="1">
-             <widget class="QLabel" name="show_electric_pot_label">
-              <property name="text">
-               <string>Electric Potential</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QSpinBox" name="nn_strips_int_box">
-              <property name="maximum">
-               <number>10</number>
-              </property>
-              <property name="value">
+              <property name="lineWidth">
                <number>2</number>
+              </property>
+              <property name="text">
+               <string>RADIATION PARAMETERS</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::PlainText</enum>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::NoTextInteraction</set>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="trappingTime_label_2">
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="layoutDirection">
+               <enum>Qt::LeftToRight</enum>
+              </property>
+              <property name="text">
+               <string>          Custom Neff Parametrization</string>
               </property>
              </widget>
             </item>
            </layout>
           </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QTabWidget" name="potentials_miniTab">
-           <property name="currentIndex">
-            <number>1</number>
-           </property>
-           <widget class="QWidget" name="noIrrad_tab">
-            <attribute name="title">
-             <string>Non Irradiated</string>
-            </attribute>
-            <widget class="QGroupBox" name="detector_properties_layout">
-             <property name="geometry">
-              <rect>
-               <x>10</x>
-               <y>10</y>
-               <width>331</width>
-               <height>311</height>
-              </rect>
-             </property>
-             <property name="font">
-              <font>
-               <pointsize>9</pointsize>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="title">
-              <string>DETECTOR PROPERTIES</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_2">
-              <item row="0" column="1">
-               <widget class="QDoubleSpinBox" name="pitch_double_box">
-                <property name="maximum">
-                 <double>100000.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>80.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="1">
-               <widget class="QDoubleSpinBox" name="depletion_voltage_double_box">
-                <property name="maximum">
-                 <double>9999.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>250.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="temperature_label">
-                <property name="text">
-                 <string>Temperature (K)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="1">
-               <widget class="QDoubleSpinBox" name="Temperature_double_box">
-                <property name="minimum">
-                 <double>0.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>9999.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>300.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="width_label">
-                <property name="text">
-                 <string>Width (um)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QDoubleSpinBox" name="depth_double_box">
-                <property name="maximum">
-                 <double>10000.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>300.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QLabel" name="depletion_voltage_label">
-                <property name="text">
-                 <string>Depletion Voltage (V)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QDoubleSpinBox" name="width_double_box">
-                <property name="maximum">
-                 <double>100000.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>25.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="depth_label">
-                <property name="text">
-                 <string>Depth (um)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="bulk_type_label">
-                <property name="text">
-                 <string>Bulk Type</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="pitch_label">
-                <property name="text">
-                 <string>Pitch (um)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QComboBox" name="bulk_type_combo_box">
-                <item>
-                 <property name="text">
-                  <string>p</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>n</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="implant_type_label">
-                <property name="text">
-                 <string>Implant Type</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QComboBox" name="implant_type_combo_box">
-                <item>
-                 <property name="text">
-                  <string>n</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>p</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-             </layout>
-             <zorder>depletion_voltage_double_box</zorder>
-             <zorder>Temperature_double_box</zorder>
-             <zorder>width_label</zorder>
-             <zorder>depth_double_box</zorder>
-             <zorder>depletion_voltage_label</zorder>
-             <zorder>width_double_box</zorder>
-             <zorder>depth_label</zorder>
-             <zorder>bulk_type_label</zorder>
-             <zorder>pitch_label</zorder>
-             <zorder>pitch_double_box</zorder>
-             <zorder>bulk_type_combo_box</zorder>
-             <zorder>implant_type_label</zorder>
-             <zorder>implant_type_combo_box</zorder>
-             <zorder>temperature_label</zorder>
-            </widget>
-           </widget>
-           <widget class="QWidget" name="irrad_tab">
-            <attribute name="title">
-             <string>Irradiated</string>
-            </attribute>
-            <layout class="QGridLayout" name="gridLayout_18">
-             <item row="5" column="1">
-              <widget class="QPushButton" name="plot_neff_button">
-               <property name="layoutDirection">
-                <enum>Qt::LeftToRight</enum>
-               </property>
-               <property name="text">
-                <string>Plot 
- 
-
- Neff</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0" colspan="2">
-              <layout class="QGridLayout" name="gridLayout_9">
-               <item row="0" column="0">
-                <widget class="QLabel" name="pitch_label_2">
-                 <property name="text">
-                  <string>z0</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QLabel" name="width_label_2">
-                 <property name="text">
-                  <string>z1</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QLabel" name="depletion_voltage_label_2">
-                 <property name="layoutDirection">
-                  <enum>Qt::LeftToRight</enum>
-                 </property>
-                 <property name="text">
-                  <string>z2</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <widget class="QLabel" name="width_label_4">
-                 <property name="text">
-                  <string>z3</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QDoubleSpinBox" name="z0_double_box">
-                 <property name="decimals">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <double>0.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>0.000000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QDoubleSpinBox" name="z1_double_box">
-                 <property name="decimals">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <double>100000.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>120.000000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="2">
-                <widget class="QDoubleSpinBox" name="z2_double_box">
-                 <property name="decimals">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <double>9999.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>220.000000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QDoubleSpinBox" name="z3_double_box">
-                 <property name="decimals">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <double>100000.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>300.000000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="pitch_label_3">
-                 <property name="text">
-                  <string>y0</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QLabel" name="width_label_3">
-                 <property name="text">
-                  <string>y1</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="2">
-                <widget class="QLabel" name="depletion_voltage_label_3">
-                 <property name="layoutDirection">
-                  <enum>Qt::LeftToRight</enum>
-                 </property>
-                 <property name="text">
-                  <string>y2</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="3">
-                <widget class="QLabel" name="width_label_5">
-                 <property name="text">
-                  <string>y3</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QDoubleSpinBox" name="y0_double_box">
-                 <property name="decimals">
-                  <number>3</number>
-                 </property>
-                 <property name="minimum">
-                  <double>-10000.000000000000000</double>
-                 </property>
-                 <property name="maximum">
-                  <double>10000.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>-25.000000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
-                <widget class="QDoubleSpinBox" name="y1_double_box">
-                 <property name="decimals">
-                  <number>3</number>
-                 </property>
-                 <property name="minimum">
-                  <double>-1000.000000000000000</double>
-                 </property>
-                 <property name="maximum">
-                  <double>1000.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>0.020000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QDoubleSpinBox" name="y2_double_box">
-                 <property name="decimals">
-                  <number>3</number>
-                 </property>
-                 <property name="minimum">
-                  <double>-100.000000000000000</double>
-                 </property>
-                 <property name="maximum">
-                  <double>100.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>0.220000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="3">
-                <widget class="QDoubleSpinBox" name="y3_double_box">
-                 <property name="decimals">
-                  <number>3</number>
-                 </property>
-                 <property name="minimum">
-                  <double>-100.000000000000000</double>
-                 </property>
-                 <property name="maximum">
-                  <double>100.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>33.000000000000000</double>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="1" column="0">
-              <widget class="QCheckBox" name="fluence_chckbx">
-               <property name="text">
-                <string>Irradiation</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-               <property name="checked">
-                <bool>false</bool>
-               </property>
-               <property name="tristate">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0" colspan="2">
-              <layout class="QGridLayout" name="gridLayout_17">
-               <item row="0" column="0">
-                <widget class="QLabel" name="trappingTime_label">
-                 <property name="text">
-                  <string>Trapping Time (ns)</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QDoubleSpinBox" name="trapping_double_box">
-                 <property name="decimals">
-                  <number>2</number>
-                 </property>
-                 <property name="minimum">
-                  <double>0.000000000000000</double>
-                 </property>
-                 <property name="maximum">
-                  <double>2000.000000000000000</double>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.000001000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>3.000000000000000</double>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="5" column="0">
-              <widget class="QCustomPlot" name="neff_map" native="true">
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QGroupBox" name="other_conf_layout">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>400</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>ADDITIONAL CONFIGURATION</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout">
+             <item row="4" column="1">
+              <widget class="QProgressBar" name="fem_progress_bar">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
+               <property name="value">
+                <number>0</number>
+               </property>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="rad_param_text">
+             <item row="4" column="2">
+              <widget class="QPushButton" name="solve_fem_button">
+               <property name="text">
+                <string>Solve FEM Problem</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QLabel" name="show_weighting_pot_label">
+               <property name="text">
+                <string>Weighting Potential</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="bias_voltage_label">
                <property name="font">
                 <font>
-                 <pointsize>9</pointsize>
                  <weight>75</weight>
                  <bold>true</bold>
                 </font>
                </property>
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
+               <property name="text">
+                <string>Bias Voltage (V)</string>
                </property>
-               <property name="frameShadow">
-                <enum>QFrame::Sunken</enum>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="n_cellsx_label">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
                </property>
-               <property name="lineWidth">
+               <property name="text">
+                <string># Cells X</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QLabel" name="n_cellsy_label">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string># Cells Y</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="2">
+              <widget class="QSpinBox" name="n_cellsy_int_box">
+               <property name="maximum">
+                <number>10000</number>
+               </property>
+               <property name="value">
+                <number>150</number>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="2">
+              <layout class="QHBoxLayout" name="show_electric_pot_buttons">
+               <item>
+                <widget class="QPushButton" name="show_electric_pot_2d_button">
+                 <property name="text">
+                  <string>Show 2D</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="show_electric_pot_3d_button">
+                 <property name="text">
+                  <string>Show 3D</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="2">
+              <widget class="QDoubleSpinBox" name="bias_voltage_double_box">
+               <property name="maximum">
+                <double>1000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>260.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="nn_strips_label">
+               <property name="text">
+                <string>Neighbour Strips</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <layout class="QHBoxLayout" name="show_weighting_pot_buttons">
+               <item>
+                <widget class="QPushButton" name="show_weighting_pot_2d_button">
+                 <property name="text">
+                  <string>Show 2D</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="show_weighting_pot_3d_button">
+                 <property name="text">
+                  <string>Show 3D</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="2" column="2">
+              <widget class="QSpinBox" name="n_cellsx_int_box">
+               <property name="maximum">
+                <number>10000</number>
+               </property>
+               <property name="value">
+                <number>150</number>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QLabel" name="show_electric_pot_label">
+               <property name="text">
+                <string>Electric Potential</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QSpinBox" name="nn_strips_int_box">
+               <property name="maximum">
+                <number>10</number>
+               </property>
+               <property name="value">
                 <number>2</number>
-               </property>
-               <property name="text">
-                <string>RADIATION PARAMETERS</string>
-               </property>
-               <property name="textFormat">
-                <enum>Qt::PlainText</enum>
-               </property>
-               <property name="textInteractionFlags">
-                <set>Qt::NoTextInteraction</set>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="trappingTime_label_2">
-               <property name="font">
-                <font>
-                 <pointsize>9</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="layoutDirection">
-                <enum>Qt::LeftToRight</enum>
-               </property>
-               <property name="text">
-                <string>          Custom Neff Parametrization</string>
                </property>
               </widget>
              </item>
             </layout>
            </widget>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="layoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>9</x>
-          <y>9</y>
-          <width>731</width>
-          <height>721</height>
-         </rect>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_10">
-         <item row="0" column="0">
-          <widget class="QCustomPlot" name="weighting_pot_qcp" native="true">
-           <property name="minimumSize">
-            <size>
-             <width>300</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCustomPlot" name="electric_pot_qcp" native="true">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="0" rowspan="2">
+         <layout class="QGridLayout" name="gridLayout_10">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMaximumSize</enum>
+          </property>
+          <item row="1" column="0">
+           <widget class="QCustomPlot" name="electric_pot_qcp" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>500</width>
+              <height>300</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCustomPlot" name="weighting_pot_qcp" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>500</width>
+              <height>300</height>
+             </size>
+            </property>
+            <zorder>electric_pot_qcp</zorder>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
       <widget class="QWidget" name="fields_tab">
        <property name="enabled">
@@ -1560,485 +1565,285 @@
        <attribute name="title">
         <string>Full Simulation</string>
        </attribute>
-       <widget class="QWidget" name="layoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>409</x>
-          <y>9</y>
-          <width>481</width>
-          <height>661</height>
-         </rect>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_13">
-         <item row="1" column="0" colspan="2">
-          <widget class="QCustomPlot" name="gen_carrier_map_qcp_2" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QPushButton" name="open_carriers_file_2">
-           <property name="text">
-            <string>Open File</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0" colspan="2">
-          <widget class="QCustomPlot" name="neff_map_2" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0" colspan="2">
-          <widget class="QPushButton" name="pushButton_2">
-           <property name="font">
-            <font>
-             <underline>true</underline>
-            </font>
-           </property>
-           <property name="layoutDirection">
-            <enum>Qt::LeftToRight</enum>
-           </property>
-           <property name="text">
-            <string>Plot Neff</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QPushButton" name="load_carriers_button_2">
-           <property name="text">
-            <string>Load File</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" rowspan="2">
-          <widget class="QLineEdit" name="filename_display_2"/>
-         </item>
-         <item row="0" column="0" colspan="2">
-          <widget class="QLabel" name="rad_param_text_3">
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-             <weight>50</weight>
-             <bold>false</bold>
-             <underline>true</underline>
-            </font>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Sunken</enum>
-           </property>
-           <property name="lineWidth">
-            <number>2</number>
-           </property>
-           <property name="text">
-            <string>Laser Beem Visualization Tool</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QLabel" name="rad_param_text_4">
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-             <weight>50</weight>
-             <bold>false</bold>
-             <underline>true</underline>
-            </font>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Sunken</enum>
-           </property>
-           <property name="lineWidth">
-            <number>2</number>
-           </property>
-           <property name="text">
-            <string> Custom Neff Visualization Tool</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="layoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>890</x>
-          <y>9</y>
-          <width>220</width>
-          <height>427</height>
-         </rect>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_12">
-         <item row="0" column="0">
-          <widget class="QGroupBox" name="detector_properties_layout_3">
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>LOOP PARAMETERS [Z-axis]</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_6">
-            <item row="0" column="0">
-             <widget class="QLabel" name="pitch_label_7">
-              <property name="text">
-               <string>Initial Position</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QDoubleSpinBox" name="depth_double_box_3">
-              <property name="maximum">
-               <double>10000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>300.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="depth_label_3">
-              <property name="text">
-               <string>Step</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QDoubleSpinBox" name="pitch_double_box_7">
-              <property name="maximum">
-               <double>100000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>80.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="width_label_11">
-              <property name="text">
-               <string>Final Position</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QDoubleSpinBox" name="width_double_box_11">
-              <property name="maximum">
-               <double>100000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>25.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QGroupBox" name="detector_properties_layout_5">
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>LOOP PARAMETERS [Y-axis]</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_8">
-            <item row="0" column="0">
-             <widget class="QLabel" name="pitch_label_9">
-              <property name="text">
-               <string>Initial Position</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QDoubleSpinBox" name="depth_double_box_5">
-              <property name="maximum">
-               <double>10000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>300.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="depth_label_5">
-              <property name="text">
-               <string>Step</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QDoubleSpinBox" name="pitch_double_box_9">
-              <property name="maximum">
-               <double>100000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>80.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="width_label_13">
-              <property name="text">
-               <string>Final Position</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QDoubleSpinBox" name="width_double_box_13">
-              <property name="maximum">
-               <double>100000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>25.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QGroupBox" name="detector_properties_layout_4">
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>LOOP PARAMETERS [Voltages]</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_7">
-            <item row="0" column="0">
-             <widget class="QLabel" name="pitch_label_8">
-              <property name="text">
-               <string>Initial Position</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QDoubleSpinBox" name="depth_double_box_4">
-              <property name="maximum">
-               <double>10000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>300.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="depth_label_4">
-              <property name="text">
-               <string>Step</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QDoubleSpinBox" name="pitch_double_box_8">
-              <property name="maximum">
-               <double>100000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>80.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="width_label_12">
-              <property name="text">
-               <string>Final Position</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QDoubleSpinBox" name="width_double_box_12">
-              <property name="maximum">
-               <double>100000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>25.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QPushButton" name="pushButton_3">
-           <property name="text">
-            <string>Run Full Simulation</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="layoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>9</x>
-          <y>9</y>
-          <width>396</width>
-          <height>651</height>
-         </rect>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_15">
-         <item row="0" column="0">
-          <widget class="QGroupBox" name="detector_properties_layout_2">
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>DETECTOR PROPERTIES</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_5">
-            <item row="2" column="1">
-             <widget class="QDoubleSpinBox" name="depth_double_box_2">
-              <property name="maximum">
-               <double>10000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>300.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="pitch_label_4">
-              <property name="text">
-               <string>Pitch (um)</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QComboBox" name="bulk_type_combo_box_2">
-              <item>
-               <property name="text">
-                <string>p</string>
+       <layout class="QGridLayout" name="gridLayout_19">
+        <item row="0" column="0">
+         <layout class="QGridLayout" name="gridLayout_15">
+          <item row="0" column="0">
+           <widget class="QGroupBox" name="detector_properties_layout_2">
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>DETECTOR PROPERTIES</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_5">
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="depth_double_box_2">
+               <property name="maximum">
+                <double>10000.000000000000000</double>
                </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>n</string>
+               <property name="value">
+                <double>300.000000000000000</double>
                </property>
-              </item>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="bulk_type_label_2">
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="pitch_label_4">
+               <property name="text">
+                <string>Pitch (um)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QComboBox" name="bulk_type_combo_box_2">
+               <item>
+                <property name="text">
+                 <string>p</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>n</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="bulk_type_label_2">
+               <property name="text">
+                <string>Bulk Type</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="0">
+              <widget class="QLabel" name="temperature_label_2">
+               <property name="text">
+                <string>Temperature (K)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="width_label_6">
+               <property name="text">
+                <string>Width (um)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QDoubleSpinBox" name="Temperature_double_box_2">
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>9999.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>300.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="depletion_voltage_label_4">
+               <property name="text">
+                <string>Depletion Voltage (V)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QComboBox" name="implant_type_combo_box_2">
+               <item>
+                <property name="text">
+                 <string>n</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>p</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="depth_label_2">
+               <property name="text">
+                <string>Depth (um)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="pitch_double_box_4">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>80.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="implant_type_label_2">
+               <property name="text">
+                <string>Implant Type</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="width_double_box_6">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>25.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_4">
+               <property name="maximum">
+                <double>9999.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>250.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <layout class="QGridLayout" name="gridLayout_14">
+            <item row="0" column="0" colspan="2">
+             <widget class="QLabel" name="rad_param_text_2">
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Sunken</enum>
+              </property>
+              <property name="lineWidth">
+               <number>2</number>
+              </property>
               <property name="text">
-               <string>Bulk Type</string>
+               <string>RADIATION PARAMETERS</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::PlainText</enum>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::NoTextInteraction</set>
               </property>
              </widget>
             </item>
-            <item row="6" column="0">
-             <widget class="QLabel" name="temperature_label_2">
+            <item row="1" column="1" colspan="2">
+             <widget class="QCheckBox" name="checkBox_2">
               <property name="text">
-               <string>Temperature (K)</string>
+               <string>Irradiation</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="width_label_6">
+            <item row="2" column="0" colspan="2">
+             <widget class="QLabel" name="trappingTime_label_3">
               <property name="text">
-               <string>Width (um)</string>
+               <string>Trapping Time (ns)</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="1">
-             <widget class="QDoubleSpinBox" name="Temperature_double_box_2">
+            <item row="2" column="3">
+             <widget class="QDoubleSpinBox" name="trapping_double_box_3">
+              <property name="decimals">
+               <number>2</number>
+              </property>
               <property name="minimum">
                <double>0.000000000000000</double>
               </property>
               <property name="maximum">
-               <double>9999.000000000000000</double>
+               <double>2000.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.000001000000000</double>
               </property>
               <property name="value">
-               <double>300.000000000000000</double>
+               <double>3.000000000000000</double>
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
-             <widget class="QLabel" name="depletion_voltage_label_4">
+            <item row="3" column="0" colspan="3">
+             <widget class="QLabel" name="trappingTime_label_4">
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="layoutDirection">
+               <enum>Qt::LeftToRight</enum>
+              </property>
               <property name="text">
-               <string>Depletion Voltage (V)</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QComboBox" name="implant_type_combo_box_2">
-              <item>
-               <property name="text">
-                <string>n</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>p</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="depth_label_2">
-              <property name="text">
-               <string>Depth (um)</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QDoubleSpinBox" name="pitch_double_box_4">
-              <property name="maximum">
-               <double>100000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>80.000000000000000</double>
+               <string>          Custom Neff Parametrization</string>
               </property>
              </widget>
             </item>
             <item row="4" column="0">
-             <widget class="QLabel" name="implant_type_label_2">
+             <widget class="QLabel" name="pitch_label_5">
               <property name="text">
-               <string>Implant Type</string>
+               <string>z0</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QDoubleSpinBox" name="width_double_box_6">
+            <item row="4" column="1">
+             <widget class="QLabel" name="width_label_7">
+              <property name="text">
+               <string>z1</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="QLabel" name="depletion_voltage_label_5">
+              <property name="layoutDirection">
+               <enum>Qt::LeftToRight</enum>
+              </property>
+              <property name="text">
+               <string>z2</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="3">
+             <widget class="QLabel" name="width_label_8">
+              <property name="text">
+               <string>z3</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QDoubleSpinBox" name="pitch_double_box_5">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <double>0.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QDoubleSpinBox" name="width_double_box_7">
+              <property name="decimals">
+               <number>1</number>
+              </property>
               <property name="maximum">
                <double>100000.000000000000000</double>
               </property>
@@ -2047,378 +1852,556 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
-             <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_4">
+            <item row="5" column="2">
+             <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_5">
+              <property name="decimals">
+               <number>1</number>
+              </property>
               <property name="maximum">
                <double>9999.000000000000000</double>
               </property>
               <property name="value">
-               <double>250.000000000000000</double>
+               <double>25.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="3">
+             <widget class="QDoubleSpinBox" name="width_double_box_8">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>25.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0">
+             <widget class="QLabel" name="pitch_label_6">
+              <property name="text">
+               <string>y0</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLabel" name="width_label_9">
+              <property name="text">
+               <string>y1</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="2">
+             <widget class="QLabel" name="depletion_voltage_label_6">
+              <property name="layoutDirection">
+               <enum>Qt::LeftToRight</enum>
+              </property>
+              <property name="text">
+               <string>y2</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="3">
+             <widget class="QLabel" name="width_label_10">
+              <property name="text">
+               <string>y3</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="0">
+             <widget class="QDoubleSpinBox" name="pitch_double_box_6">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>80.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="1">
+             <widget class="QDoubleSpinBox" name="width_double_box_10">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>25.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="2">
+             <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_6">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <double>9999.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>25.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="3">
+             <widget class="QDoubleSpinBox" name="width_double_box_9">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <double>100000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>25.000000000000000</double>
               </property>
              </widget>
             </item>
            </layout>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <layout class="QGridLayout" name="gridLayout_14">
-           <item row="0" column="0" colspan="2">
-            <widget class="QLabel" name="rad_param_text_2">
-             <property name="font">
-              <font>
-               <pointsize>9</pointsize>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Sunken</enum>
-             </property>
-             <property name="lineWidth">
-              <number>2</number>
-             </property>
-             <property name="text">
-              <string>RADIATION PARAMETERS</string>
-             </property>
-             <property name="textFormat">
-              <enum>Qt::PlainText</enum>
-             </property>
-             <property name="textInteractionFlags">
-              <set>Qt::NoTextInteraction</set>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1" colspan="2">
-            <widget class="QCheckBox" name="checkBox_2">
-             <property name="text">
-              <string>Irradiation</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0" colspan="2">
-            <widget class="QLabel" name="trappingTime_label_3">
-             <property name="text">
-              <string>Trapping Time (ns)</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="3">
-            <widget class="QDoubleSpinBox" name="trapping_double_box_3">
-             <property name="decimals">
-              <number>2</number>
-             </property>
-             <property name="minimum">
-              <double>0.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>2000.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.000001000000000</double>
-             </property>
-             <property name="value">
-              <double>3.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0" colspan="3">
-            <widget class="QLabel" name="trappingTime_label_4">
-             <property name="font">
-              <font>
-               <pointsize>9</pointsize>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="layoutDirection">
-              <enum>Qt::LeftToRight</enum>
-             </property>
-             <property name="text">
-              <string>          Custom Neff Parametrization</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="pitch_label_5">
-             <property name="text">
-              <string>z0</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QLabel" name="width_label_7">
-             <property name="text">
-              <string>z1</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="2">
-            <widget class="QLabel" name="depletion_voltage_label_5">
-             <property name="layoutDirection">
-              <enum>Qt::LeftToRight</enum>
-             </property>
-             <property name="text">
-              <string>z2</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="3">
-            <widget class="QLabel" name="width_label_8">
-             <property name="text">
-              <string>z3</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QDoubleSpinBox" name="pitch_double_box_5">
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <double>0.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>0.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QDoubleSpinBox" name="width_double_box_7">
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <double>100000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>25.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="2">
-            <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_5">
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <double>9999.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>25.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="3">
-            <widget class="QDoubleSpinBox" name="width_double_box_8">
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <double>100000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>25.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="pitch_label_6">
-             <property name="text">
-              <string>y0</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <widget class="QLabel" name="width_label_9">
-             <property name="text">
-              <string>y1</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="2">
-            <widget class="QLabel" name="depletion_voltage_label_6">
-             <property name="layoutDirection">
-              <enum>Qt::LeftToRight</enum>
-             </property>
-             <property name="text">
-              <string>y2</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="3">
-            <widget class="QLabel" name="width_label_10">
-             <property name="text">
-              <string>y3</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0">
-            <widget class="QDoubleSpinBox" name="pitch_double_box_6">
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <double>100000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>80.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="1">
-            <widget class="QDoubleSpinBox" name="width_double_box_10">
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <double>100000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>25.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="2">
-            <widget class="QDoubleSpinBox" name="depletion_voltage_double_box_6">
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <double>9999.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>25.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="3">
-            <widget class="QDoubleSpinBox" name="width_double_box_9">
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <double>100000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>25.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="2" column="0">
-          <widget class="QGroupBox" name="other_conf_layout_2">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>ADDITIONAL CONFIGURATION</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_16">
-            <item row="0" column="1">
-             <widget class="QDoubleSpinBox" name="bias_voltage_double_box_2">
-              <property name="maximum">
-               <double>1000.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>260.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QSpinBox" name="n_cellsy_int_box_2">
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-              <property name="value">
-               <number>150</number>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="nn_strips_int_box_2">
-              <property name="maximum">
-               <number>10</number>
-              </property>
-              <property name="value">
-               <number>2</number>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="n_cellsx_label_2">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string># Cells X</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="nn_strips_label_2">
-              <property name="text">
-               <string>Neighbour Strips</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QSpinBox" name="n_cellsx_int_box_2">
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-              <property name="value">
-               <number>150</number>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="bias_voltage_label_2">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>Bias Voltage (V)</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="n_cellsy_label_2">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string># Cells Y</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QGroupBox" name="other_conf_layout_2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>ADDITIONAL CONFIGURATION</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_16">
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="bias_voltage_double_box_2">
+               <property name="maximum">
+                <double>1000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>260.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QSpinBox" name="n_cellsy_int_box_2">
+               <property name="maximum">
+                <number>10000</number>
+               </property>
+               <property name="value">
+                <number>150</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="nn_strips_int_box_2">
+               <property name="maximum">
+                <number>10</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="n_cellsx_label_2">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string># Cells X</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="nn_strips_label_2">
+               <property name="text">
+                <string>Neighbour Strips</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QSpinBox" name="n_cellsx_int_box_2">
+               <property name="maximum">
+                <number>10000</number>
+               </property>
+               <property name="value">
+                <number>150</number>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="bias_voltage_label_2">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Bias Voltage (V)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="n_cellsy_label_2">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string># Cells Y</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="1">
+         <layout class="QGridLayout" name="gridLayout_13">
+          <item row="1" column="0" colspan="2">
+           <widget class="QCustomPlot" name="gen_carrier_map_qcp_2" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="open_carriers_file_2">
+            <property name="text">
+             <string>Open File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="2">
+           <widget class="QCustomPlot" name="neff_map_2" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QPushButton" name="plot_neff_button2">
+            <property name="font">
+             <font>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string>Plot Neff</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QPushButton" name="load_carriers_button_2">
+            <property name="text">
+             <string>Load File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" rowspan="2">
+           <widget class="QLineEdit" name="filename_display_2"/>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="rad_param_text_3">
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+              <weight>50</weight>
+              <bold>false</bold>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Sunken</enum>
+            </property>
+            <property name="lineWidth">
+             <number>2</number>
+            </property>
+            <property name="text">
+             <string>Laser Beem Visualization Tool</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::NoTextInteraction</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QLabel" name="rad_param_text_4">
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+              <weight>50</weight>
+              <bold>false</bold>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Sunken</enum>
+            </property>
+            <property name="lineWidth">
+             <number>2</number>
+            </property>
+            <property name="text">
+             <string> Custom Neff Visualization Tool</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::NoTextInteraction</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="2">
+         <layout class="QGridLayout" name="gridLayout_12">
+          <item row="0" column="0">
+           <widget class="QGroupBox" name="detector_properties_layout_3">
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>LOOP PARAMETERS [Z-axis]</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_6">
+             <item row="0" column="0">
+              <widget class="QLabel" name="pitch_label_7">
+               <property name="text">
+                <string>Initial Position</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="depth_double_box_3">
+               <property name="maximum">
+                <double>10000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>300.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="depth_label_3">
+               <property name="text">
+                <string>Step</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="pitch_double_box_7">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>80.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="width_label_11">
+               <property name="text">
+                <string>Final Position</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="width_double_box_11">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>25.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QGroupBox" name="detector_properties_layout_5">
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>LOOP PARAMETERS [Y-axis]</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_8">
+             <item row="0" column="0">
+              <widget class="QLabel" name="pitch_label_9">
+               <property name="text">
+                <string>Initial Position</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="depth_double_box_5">
+               <property name="maximum">
+                <double>10000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>300.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="depth_label_5">
+               <property name="text">
+                <string>Step</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="pitch_double_box_9">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>80.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="width_label_13">
+               <property name="text">
+                <string>Final Position</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="width_double_box_13">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>25.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QGroupBox" name="detector_properties_layout_4">
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>LOOP PARAMETERS [Voltages]</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_7">
+             <item row="0" column="0">
+              <widget class="QLabel" name="pitch_label_8">
+               <property name="text">
+                <string>Initial Position</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="depth_double_box_4">
+               <property name="maximum">
+                <double>10000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>300.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="depth_label_4">
+               <property name="text">
+                <string>Step</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="pitch_double_box_8">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>80.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="width_label_12">
+               <property name="text">
+                <string>Final Position</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="width_double_box_12">
+               <property name="maximum">
+                <double>100000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>25.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QPushButton" name="pushButton_3">
+            <property name="text">
+             <string>Run Full Simulation</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
      </widget>
     </item>
@@ -2429,7 +2412,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1221</width>
+     <width>1236</width>
      <height>27</height>
     </rect>
    </property>

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -263,7 +263,7 @@ std::string utilities::vector_to_string(std::vector<double> input_list)
 
 // Utility to read values for the simulation so main need not be compiled everytime
 // one wishes to modify the simulation parameters
-void utilities::parse_config_file(std::string fileName, double &depth, double &width, double &pitch, int &nns, double &temp, double &trapping, double &fluence, int &nThreads, int &n_cells_x, int &n_cells_y, char &bulk_type, char &implant_type, int &waveLength, std::string &scanType, double &C, double &dt, double &max_time, double &v_bias, double &v_init, double &deltaV, double &v_max, double &v_depletion, double &zInit, double &zMax, double &deltaZ, double &yInit, double &yMax, double &deltaY, std::vector<double> &neff_param)
+void utilities::parse_config_file(std::string fileName, std::string &carrierFile, double &depth, double &width, double &pitch, int &nns, double &temp, double &trapping, double &fluence, int &nThreads, int &n_cells_x, int &n_cells_y, char &bulk_type, char &implant_type, int &waveLength, std::string &scanType, double &C, double &dt, double &max_time, double &v_init, double &deltaV, double &v_max, double &v_depletion, double &zInit, double &zMax, double &deltaZ, double &yInit, double &yMax, double &deltaY, std::vector<double> &neff_param)
 {
 	// Creat map to hold all values as strings 
 	std::map< std::string, std::string> valuesMap;
@@ -388,13 +388,6 @@ void utilities::parse_config_file(std::string fileName, double &depth, double &w
 	converter.str("");
 	tempString = std::string("");
 
-	tempString = std::string("ScanStep");
-	converter << valuesMap[tempString];
-	converter >> scanType;
-	converter.clear();
-	converter.str("");
-	tempString = std::string("");
-
 	tempString = std::string("Capacitance");
 	converter << valuesMap[tempString];
 	converter >> C;
@@ -412,13 +405,6 @@ void utilities::parse_config_file(std::string fileName, double &depth, double &w
 	tempString = std::string("TotalTime");
 	converter << valuesMap[tempString];
 	converter >> max_time;
-	converter.clear();
-	converter.str("");
-	tempString = std::string("");
-
-	tempString = std::string("BiasVoltage");
-	converter << valuesMap[tempString];
-	converter >> v_bias;
 	converter.clear();
 	converter.str("");
 	tempString = std::string("");
@@ -493,6 +479,10 @@ void utilities::parse_config_file(std::string fileName, double &depth, double &w
 	converter.str("");
 	tempString = std::string("");
 
+	tempString = std::string("CarrierFile");
+	carrierFile = valuesMap[tempString];
+	tempString = std::string("");
+
 	tempString = std::string("y0");
 	converter << valuesMap[tempString];
 	converter >> neff_param[0];
@@ -547,3 +537,228 @@ void utilities::parse_config_file(std::string fileName, double &depth, double &w
 		std::cout << "Error opening the file. Does the file " << fileName << " exist?" << std::endl;
 	}
 }
+
+
+
+// Utility to read values for the simulation so main need not be compiled everytime
+// one wishes to modify the simulation parameters
+void utilities::parse_config_file(std::string fileName, std::string &carrierFile, double &depth, double &width, double &pitch, int &nns, double &temp, double &trapping, double &fluence, int &n_cells_x, int &n_cells_y, char &bulk_type, char &implant_type, double &C, double &dt, double &max_time, double &vBias, double &vDepletion, double &zPos, double &yPos, std::vector<double> &neff_param)
+{
+	// Creat map to hold all values as strings 
+	std::map< std::string, std::string> valuesMap;
+	std::string id, eq, val;
+	std::stringstream converter;
+	std::string tempString;
+
+	std::ifstream configFile(fileName, std::ios_base::in);
+
+	if (configFile.is_open())
+	{
+
+		std::string line;
+		char comment = '#';
+		char empty = '\0';
+		char tab = '\t';
+		while(std::getline(configFile, line))
+		{
+			char start = line[0];
+			if (start == comment || start == empty || start == tab) continue;  // skip comments
+			std::istringstream isstream(line);
+			isstream >> id >> eq >> val;
+			if (eq != "=") 
+			{
+			std::cout << "Error ecountered while reading '" << id << std::endl;
+			break;
+			}
+			else
+			{
+			// Store value on map as map[variabel] = value
+			valuesMap[id] = val;
+			}
+		}
+
+
+	tempString = std::string("Depth");
+	converter << valuesMap[tempString];
+	converter >> depth;
+	converter.str("");
+	converter.clear();
+	tempString = std::string("");
+	
+	tempString = std::string("Width");
+	converter << valuesMap[tempString];
+	converter >> width;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("Pitch");
+	converter << valuesMap[tempString];
+	converter >> pitch;
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("NeighbouringStrips");
+	converter << valuesMap[tempString];
+	converter >> nns;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("Temperature");
+	converter << valuesMap[tempString];
+	converter >> temp;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("TrappingTime");
+	converter << valuesMap[tempString];
+	converter >> trapping;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("Fluence");
+	converter << valuesMap[tempString];
+	converter >> fluence;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("CellsX");
+	converter << valuesMap[tempString];
+	converter >> n_cells_x;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("CellsY");
+	converter << valuesMap[tempString];
+	converter >> n_cells_y;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("Bulk");
+	converter << valuesMap[tempString];
+	converter >> bulk_type;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("Implant");
+	converter << valuesMap[tempString];
+	converter >> implant_type;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("Capacitance");
+	converter << valuesMap[tempString];
+	converter >> C;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("TimeStep");
+	converter << valuesMap[tempString];
+	converter >> dt;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("TotalTime");
+	converter << valuesMap[tempString];
+	converter >> max_time;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("InitialVoltage");
+	converter << valuesMap[tempString];
+	converter >> vBias;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("DepletionVoltage");
+	converter << valuesMap[tempString];
+	converter >> vDepletion;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("InitialZ");
+	converter << valuesMap[tempString];
+	converter >> zPos;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("InitialY");
+	converter << valuesMap[tempString];
+	converter >> yPos;
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("CarrierFile");
+	carrierFile = valuesMap[tempString];
+	tempString = std::string("");
+
+	tempString = std::string("y0");
+	converter << valuesMap[tempString];
+	converter >> neff_param[0];
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("y1");
+	converter << valuesMap[tempString];
+	converter >> neff_param[1];
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("y2");
+	converter << valuesMap[tempString];
+	converter >> neff_param[2];
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("y3");
+	converter << valuesMap[tempString];
+	converter >> neff_param[3];
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	//z0 = 0.0
+	neff_param[4] = 0.0;
+
+	tempString = std::string("z1");
+	converter << valuesMap[tempString];
+	converter >> neff_param[5];
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	tempString = std::string("z2");
+	converter << valuesMap[tempString];
+	converter >> neff_param[6];
+	converter.clear();
+	converter.str("");
+	tempString = std::string("");
+
+	//z3 = depth
+	neff_param[7] = depth;
+
+	}
+	else
+{
+		std::cout << "Error opening the file. Does the file " << fileName << " exist?" << std::endl;
+	}
+}
+

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -21,14 +21,15 @@ using namespace dolfin;
 
 namespace utilities
 {
-  TH2D export_to_histogram(Function &func, TString hist_name, TString hist_title, int n_bins_x , double x_min, double x_max, int n_bins_y, double y_min, double y_max);
-  void paint_TH2D_qcp(TH2D hist, QCPColorMap * color_map);
-  void write_results_to_file(QString filename, QVector<QVector<double>> results);
-  void write_to_file_row(std::string filename, QVector<QVector<double>> results, double dt);
+	TH2D export_to_histogram(Function &func, TString hist_name, TString hist_title, int n_bins_x , double x_min, double x_max, int n_bins_y, double y_min, double y_max);
+	void paint_TH2D_qcp(TH2D hist, QCPColorMap * color_map);
+	void write_results_to_file(QString filename, QVector<QVector<double>> results);
+	void write_to_file_row(std::string filename, QVector<QVector<double>> results, double dt);
 	void write_to_file_row(std::string filename, TH1D *hconv, double temp, double yShift, double height, double voltage);
 	void write_to_hetct_header(std::string filename, SMSDetector detector, double C, double dt, std::vector<double> y_shifts, std::vector<double> z_shifts, double landa, std::string type, std::string carriers_file, std::vector<double> voltages);
 	std::string vector_to_string(std::vector<double> input_list);
-void parse_config_file(std::string fileName, double &depth, double &width, double &pitch, int &nns, double &temp, double &trapping, double &fluence, int &nThreads, int &n_cells_x, int &n_cells_y, char &bulk_type, char &implant_type, int &waveLength, std::string &scanType, double &C, double &dt, double &max_time, double &v_bias, double &v_init, double &deltaV, double &v_max, double &v_depletion, double &zInit, double &zMax, double &deltaZ, double &yInit, double &yMax, double &deltaY, std::vector<double> &neff_param);
+	void parse_config_file(std::string fileName, std::string &carrierFile, double &depth, double &width, double &pitch, int &nns, double &temp, double &trapping, double &fluence, int &nThreads, int &n_cells_x, int &n_cells_y, char &bulk_type, char &implant_type, int &waveLength, std::string &scanType, double &C, double &dt, double &max_time, double &v_init, double &deltaV, double &v_max, double &v_depletion, double &zInit, double &zMax, double &deltaZ, double &yInit, double &yMax, double &deltaY, std::vector<double> &neff_param);
+	void parse_config_file(std::string fileName, std::string &carrierFile, double &depth, double &width, double &pitch, int &nns, double &temp, double &trapping, double &fluence, int &n_cells_x, int &n_cells_y, char &bulk_type, char &implant_type, double &C, double &dt, double &max_time, double &vBias,double &vDepletion, double &zPos, double &yPos, std::vector<double> &neff_param);
 }
 
 #endif // UTILITIES_H


### PR DESCRIPTION
There has been implemented a class designed specifically to allow other programs to leverage TRACS capabilities without messing up with the code. This TRACSInterface includes the ability to simulate one transient at a time. 

More simulation flexibility might come in the future to allow full utilization of TRACS from another program.

In addition to TRACSInterface the GUI has been upgraded to simulated irradiated silicon detectors. The new GUI includes the ability to select wether or not the detector has been irradiated and set its trapping time and the corresponding  Neff to the specific detector.

Full Simulation GUI is still empty but will not remain like that for long.